### PR TITLE
Create output folder and use json dump

### DIFF
--- a/BvhToMimic.py
+++ b/BvhToMimic.py
@@ -42,8 +42,11 @@ def bvhBoneName(mimicBone):
 
 # Initialization
 # ===========================================================================
+dirname = "./OutputMimic/"
+if not os.path.exists(dirname):
+    os.makedirs(dirname)
 
-removeAllFilesInDirectory("./OutputMimic/")
+removeAllFilesInDirectory(dirname)
 
 # get json of humanoidRig
 with open(f"./Rigs/humanoidRig.json") as json_data:

--- a/BvhToMimic.py
+++ b/BvhToMimic.py
@@ -74,11 +74,8 @@ for j in range(0, len(onlyfiles)):
 
     with open(f"./OutputMimic/{onlyfiles[j]}.txt", "w") as output:
 
-        # File Header
-        print(f"{{", file=output)
-        print(f"\"Loop\": \"none\",", file=output)
-        print(f"\"Frames\":", file=output)
-        print(f"[", file=output)
+        # list containing all the frames
+        frames = []
 
         # open file to convert
         with open("./inputBvh/" + onlyfiles[j]) as f:
@@ -133,22 +130,12 @@ for j in range(0, len(onlyfiles)):
                         keyFrame.append(quaternion[2])
                         keyFrame.append(quaternion[3])
 
-                # Turn keyFrame into a recordable JSON String
-                keyFrameString = "["
-                keyFrameString += str(keyFrame[0])
+                frames.append(keyFrame)
 
-                for x in range(0, len(keyFrame)):
-                    if x > 0:
-                        keyFrameString += ","
-                        keyFrameString += str(keyFrame[x])
+            # output in dictionary format for easy json dump
+            outputDict = {
+                "Loop": "none", # "none" or "wrap"
+                "Frames": frames
+            }
 
-                # Put comma at end of all keyFrame lines but the last
-                keyFrameString += "]"
-                if i < mocap.nframes - 1:
-                    keyFrameString += ","
-
-                print(f"{keyFrameString}", file=output)
-
-            # Close JSON object
-            print(f"]", file=output)
-            print(f"}}", file=output)
+            json.dump(outputDict, output, indent=4)


### PR DESCRIPTION
This pull request has two small changes.

* Create output folder if it doesn't exist.
* Use the `json.dump()` method to write the DeepMimic json output file. 

If you prefer to keep your manual way of (which doesn't indent and doesn't format individual keyFrame elements) you'll have to remove commit 0280c16.