### PR TITLE
Correct joint rotations

### DIFF
--- a/BvhToMimic.py
+++ b/BvhToMimic.py
@@ -138,6 +138,10 @@ for j in range(0, len(onlyfiles)):
                             math.radians(x), math.radians(y), math.radians(z)
                         )
 
+                        # rotate by 180 degrees around y axis to coincide with DeepMimic axes.
+                        yRot = EulerXYZToQuaternion(0, math.radians(180), 0)
+                        quaternion = yRot * quaternion
+
                         keyFrame.append(quaternion[0])
                         keyFrame.append(quaternion[1])
                         keyFrame.append(quaternion[2])

--- a/BvhToMimic.py
+++ b/BvhToMimic.py
@@ -9,6 +9,7 @@ import os
 from os import listdir
 from os.path import isfile, join
 from tqdm import tqdm
+from pyquaternion import Quaternion
 
 # Function declarations
 # ===========================================================================
@@ -35,6 +36,21 @@ def euler_to_quaternion(heading, attitude, bank):
     z = c1*s2*c3 - s1*c2*s3
     return [w, x, y, z]
 
+def EulerXYZToQuaternion(Xangle, Yangle, Zangle):
+    cy = math.cos(Xangle * 0.5)
+    sy = math.sin(Xangle * 0.5)
+    cp = math.cos(Yangle * 0.5)
+    sp = math.sin(Yangle * 0.5)
+    cr = math.cos(Zangle * 0.5)
+    sr = math.sin(Zangle * 0.5)
+
+    q = Quaternion()
+    q[0] = cy * cp * cr + sy * sp * sr
+    q[1] = cy * cp * sr - sy * sp * cr
+    q[2] = sy * cp * sr + cy * sp * cr
+    q[3] = sy * cp * cr - cy * sp * sr
+
+    return q
 
 def bvhBoneName(mimicBone):
     return humanoidRig[f"{mimicBone}"]
@@ -118,13 +134,10 @@ for j in range(0, len(onlyfiles)):
                         z = mocap.frame_joint_channel(
                             i, bvhBoneName(deepMimicHumanoidJoints[p]), 'Zrotation')
 
-                        # bindings from blender test
-                        pitch = x
-                        yaw = y
-                        roll = z
+                        quaternion = EulerXYZToQuaternion(
+                            math.radians(x), math.radians(y), math.radians(z)
+                        )
 
-                        quaternion = euler_to_quaternion(math.radians(
-                            yaw), math.radians(pitch), math.radians(roll))
                         keyFrame.append(quaternion[0])
                         keyFrame.append(quaternion[1])
                         keyFrame.append(quaternion[2])

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ bvh `pip install bvh`
 
 tqdm `pip install tqdm`
 
+pyquaternion `pip install pyquaternion`
+
 ## Creating a humanoid rig
 
 Currently joints in .bvh files have to be manually assigned by name to the corresponding joints in the Mimic Motion humanoid rig. This is done by assigning .bvh model's bone names to the corresponding joint properties in [./Rigs/humanoidRig.json](./Rigs/humanoidRig.json)


### PR DESCRIPTION
This pull request fixes the joint rotation problem mentioned [here](https://github.com/SleepingFox88/BvhToMimic/issues/4#issuecomment-511452239).

(Solution was a simple 180 degree rotation around the y-axis for every joint.) I tested this on two different BVH files, one of which was provided by you in the repository and the other one from [here](http://mocap.cs.sfu.ca/). Both of them worked.

Issue #4 is still a thing, I'll continue looking at that now.